### PR TITLE
fix: lgcstat failure due to invalid field access

### DIFF
--- a/luajit21.py
+++ b/luajit21.py
@@ -2567,7 +2567,18 @@ Usage: lgcstat"""
         # step 3: Figure out the size of misc data structures
         strhash_size = (strmask(g) + 1) * typ("GCRef").sizeof
 
-        g_tmpbuf_sz = int(g['tmpbuf']['e']) - int(g['tmpbuf']['b'])
+        def get_ptr_value(ptr_val):
+            if ptr_val.type.name == 'GCRef':
+                if is_gc64():
+                    return int(ptr_val['ptr64'])
+                else:
+                    return int(ptr_val['ptr32'])
+            else:
+                return int(ptr_val)
+
+        e_val = g['tmpbuf']['e']
+        b_val = g['tmpbuf']['b']
+        g_tmpbuf_sz = get_ptr_value(e_val) - get_ptr_value(b_val)
 
         jit_state_sz = self.get_jit_state_sz(G2J(g))
         ctype_state_sz = 0

--- a/luajit21.py
+++ b/luajit21.py
@@ -2567,10 +2567,7 @@ Usage: lgcstat"""
         # step 3: Figure out the size of misc data structures
         strhash_size = (strmask(g) + 1) * typ("GCRef").sizeof
 
-        if is_gc64():
-            g_tmpbuf_sz = g['tmpbuf']['e']['ptr64'] - g['tmpbuf']['b']['ptr64']
-        else:
-            g_tmpbuf_sz = g['tmpbuf']['e']['ptr32'] - g['tmpbuf']['b']['ptr32']
+        g_tmpbuf_sz = int(g['tmpbuf']['e']) - int(g['tmpbuf']['b'])
 
         jit_state_sz = self.get_jit_state_sz(G2J(g))
         ctype_state_sz = 0


### PR DESCRIPTION
- Running lgcstat

```bash
(gdb) lgcstat
Traceback (most recent call last):
  File "luajit21.py", line 2571, in invoke
    g_tmpbuf_sz = g['tmpbuf']['e']['ptr64'] - g['tmpbuf']['b']['ptr64']
                  ~~~~~~~~~~~~~~~~^^^^^^^^^
gdb.error: Attempt to extract a component of a value that is not a struct/class/union.
Error occurred in Python: Attempt to extract a component of a value that is not a struct/class/union.

```

## Issue in code

1. **Identify the Issue:** The error occurs because `g['tmpbuf']['e']` and `g['tmpbuf']['b']` are pointer values, not structs with `ptr64` or `ptr32` fields. Accessing those fields leads to a GDB error.
2. **Correct Approach:** Instead of trying to extract union fields, directly convert the pointers to integers and subtract them to get the buffer size.
3. **Modify the Code:** Replace the conditional checks for GC64 with a direct integer subtraction of the `e` and `b` pointers.

### Modified change

```bash
        # Original lines causing the error:
        # if is_gc64():
        #     g_tmpbuf_sz = g['tmpbuf']['e']['ptr64'] - g['tmpbuf']['b']['ptr64']
        # else:
        #     g_tmpbuf_sz = g['tmpbuf']['e']['ptr32'] - g['tmpbuf']['b']['ptr32']

        # Corrected code:
        g_tmpbuf_sz = int(g['tmpbuf']['e']) - int(g['tmpbuf']['b'])
```

## After Fix

```bash
(gdb) lgcstat
6372 str        objects: max=18665, avg = 47, min=26, sum=302914
2708 upval      objects: max=48, avg = 48, min=48, sum=129984
1 thread     objects: max=1304, avg = 1304, min=1304, sum=1304
1799 proto      objects: max=17610, avg = 437, min=114, sum=786469
2364 func       objects: max=240, avg = 59, min=40, sum=140456
99 trace      objects: max=2424, avg = 808, min=200, sum=80020
212 cdata      objects: max=262200, avg = 2455, min=18, sum=520562
2161 tab        objects: max=6208, avg = 180, min=64, sum=389456
47 udata      objects: max=16936, avg = 1167, min=56, sum=54880

sizeof strhash 131072
sizeof g->tmpbuf 4096
sizeof ctype_state 25096
sizeof jit_state 14848

total sz 2587341
g->strnum 6372, g->gc.total 2596935
elapsed: 0.684245 sec
(gdb)
```